### PR TITLE
Android P 网络策略 适配，会导致Glide TIKTOK案例，列表缩略图 无法加载

### DIFF
--- a/dkplayer-sample/src/main/AndroidManifest.xml
+++ b/dkplayer-sample/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"

--- a/dkplayer-sample/src/main/res/xml/network_security_config.xml
+++ b/dkplayer-sample/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true" />
+</network-security-config>


### PR DESCRIPTION
cleartext communication to xxx not permitted by network security policy