### PR TITLE
解决Android10  在无缝播放切换到详情页时，锁屏或home键返回， 导致返回转场动画失效的问题

### DIFF
--- a/constants.gradle
+++ b/constants.gradle
@@ -3,7 +3,7 @@ project.ext {
     releaseVersionCode = 47
 
     minSdkVersion = 16
-    targetSdkVersion = 29
+    targetSdkVersion = 27
     compileSdkVersion = 29
     buildToolsVersion = '28.0.3'
 


### PR DESCRIPTION
 Android10 Activity的onStop方法会导致共享元素动画失效，通过反射注入恢复共享元素动画。

但需要同时配置项目的targetSdkVersion <= 27 ， 因为Android10把反射也禁止了。